### PR TITLE
Dev global fit

### DIFF
--- a/examples/Global_Fit_config.yaml
+++ b/examples/Global_Fit_config.yaml
@@ -88,8 +88,8 @@ datasets:
     binning:
       type: RectangularBinning
       bin_vars_edges:
-        - ["log10_reco_energy", [2.5,7,46]]
-        - ["cos_reco_zenith", [-1, 0.0872, 34]]
+        - ["log10_reco_energy", "linear", [2.5,7,46]]
+        - ["cos_reco_zenith", "linear", [-1, 0.0872, 34]]
     hist_factors:
       - name: SnowStormSystematicsNT
         type: SnowStormGradient
@@ -110,8 +110,9 @@ datasets:
     binning:
       type: RectangularBinning
       bin_vars_edges:
-        - ["log10_reco_energy",  [2.8,7,22]]
-        - ["cos_reco_zenith",  [-1, 1, 16]]
+        - ["log10_reco_energy", "linear", [2.8,7,22]]
+        - ["cos_reco_zenith", "array", [-1., 0.2, 0.6, 1.]]
+        #- ["cos_reco_zenith", "linear", [-1, 1, 16]]
     hist_factors: 
       - name: SnowStormSystematicsCasc
         type: SnowStormGradient
@@ -133,8 +134,8 @@ datasets:
     binning:
       type: RectangularBinning
       bin_vars_edges:
-        - ["log10_reco_energy",  [2.6, 4.8, 2]]
-        - ["cos_reco_zenith",  [-1, 1, 2]]
+        - ["log10_reco_energy", "linear", [2.6, 4.8, 2]]
+        - ["cos_reco_zenith", "linear", [-1, 1, 2]]
     hist_factors:
       - name: SnowStormSystematicsCascMu
         type: SnowStormGradient

--- a/pyForwardFolding/binning.py
+++ b/pyForwardFolding/binning.py
@@ -153,9 +153,14 @@ class RectangularBinning(AbstractBinning):
             raise ValueError("At least one variable and its edges must be provided.")
         bin_edges = []
         bin_variables = []
-        for var, edges in bin_vars_edges:
+        for var, bin_type, edges in bin_vars_edges:
             bin_variables.append(var)
-            bin_edges.append(backend.linspace(*edges))
+            if bin_type == "linear":
+                bin_edges.append(backend.linspace(*edges))
+            elif bin_type == "array":
+                bin_edges.append(backend.array(edges))
+            else:
+                raise ValueError(f"Unknown binning type: {bin_type}")
         return cls(bin_variables, bin_edges)
 
     @property

--- a/pyForwardFolding/factor.py
+++ b/pyForwardFolding/factor.py
@@ -218,13 +218,11 @@ class DeltaGamma(AbstractFactor):
         reference_energy (float): Reference energy for scaling.
     """
 
-
-
-    def __init__(self, name, param_mapping: Dict[str, str] = None):
+    def __init__(self, name, param_mapping: Dict[str, str] = None, reference_energy: float = 1.0):
         super().__init__(name, param_mapping)
-        #self.reference_energy = reference_energy
+        self.reference_energy = reference_energy
 
-        self.factor_parameters =  ["delta_gamma"]
+        self.factor_parameters = ["delta_gamma"]
         self.req_vars = ["true_energy", "median_energy"]
 
     @classmethod
@@ -232,7 +230,7 @@ class DeltaGamma(AbstractFactor):
         param_mapping = config.get("param_mapping", None)
         return DeltaGamma(
                 name=config["name"],
-                #reference_energy=config["reference_energy"],
+                reference_energy=config["reference_energy"],
                 param_mapping=param_mapping,
         )
 
@@ -242,8 +240,8 @@ class DeltaGamma(AbstractFactor):
 
         delta_gamma = exposed_values["delta_gamma"]
         true_energy = input_values["true_energy"]
-        median_energy = input_values["median_energy"]
-        return backend.power(true_energy / median_energy, -delta_gamma)
+        # median_energy = input_values["median_energy"]
+        return backend.power(true_energy / self.reference_energy, -delta_gamma)
 
 
 class ModelInterpolator(AbstractFactor):
@@ -282,7 +280,7 @@ class ModelInterpolator(AbstractFactor):
         baseline_weight = input_values[self.base_key]
         alternative_weight = input_values[self.alt_key]
         lambda_int = exposed_values["lambda_int"]
-        return lambda_int + (1-lambda_int)*alternative_weight/baseline_weight
+        return (1-lambda_int) + lambda_int*alternative_weight/baseline_weight
 
 
 class GradientReweight(AbstractFactor):

--- a/pyForwardFolding/likelihood.py
+++ b/pyForwardFolding/likelihood.py
@@ -108,6 +108,6 @@ class GaussianUnivariatePrior(AbstractPrior):
 
     def log_pdf(self, exposed_parameters):
         llh = 0
-        for par, (mean, std) in self.prior.items():
+        for par, (mean, std) in self.prior_params.items():
             llh += (exposed_parameters[par] - mean)**2 / std**2
         return llh

--- a/pyForwardFolding/minimizer.py
+++ b/pyForwardFolding/minimizer.py
@@ -108,7 +108,7 @@ class WrappedLLH:
                                           self.datasets,
                                           restructured_args)
         for p in self.prior:
-            binned_llh += p.evaluate(restructured_args)
+            binned_llh += p.log_pdf(restructured_args)
         return binned_llh
 
 


### PR DESCRIPTION
Some fixes and changes to the factors of the conventional flux mainly. 
1. The delta_gamma parameter gets a reference energy again (which can be different for prompt and conv), but is not evaluated on a per dataset level. 
2. The lambda_CR parameter was interpolating in the wrong direction (1 was default, instead of 0). 
3. Added the option to give rectangular binning and array instead of linspace args, to allow for binnigs like the 3 Cscd bin in the global fit. This can be adapted to things like a log binning, if necessary. 
4. The prior class was still not running correctly and needed a fix