### PR TITLE
fix: raise error on zero baseline weights

### DIFF
--- a/pyForwardFolding/factor.py
+++ b/pyForwardFolding/factor.py
@@ -280,6 +280,10 @@ class ModelInterpolator(AbstractFactor):
         baseline_weight = input_values[self.base_key]
         alternative_weight = input_values[self.alt_key]
         lambda_int = exposed_values["lambda_int"]
+
+        if np.any(baseline_weight==0):
+            raise ValueError(f"Baseline weights for ModelInterpolator contain at least one 0. Remove those events from the input.")
+
         return (1-lambda_int) + lambda_int*alternative_weight/baseline_weight
 
 

--- a/pyForwardFolding/factor.py
+++ b/pyForwardFolding/factor.py
@@ -282,7 +282,7 @@ class ModelInterpolator(AbstractFactor):
         lambda_int = exposed_values["lambda_int"]
 
         if np.any(baseline_weight==0):
-            raise ValueError(f"Baseline weights for ModelInterpolator contain at least one 0. Remove those events from the input.")
+            raise ValueError("Baseline weights for ModelInterpolator contain at least one 0. Remove those events from the input.")
 
         return (1-lambda_int) + lambda_int*alternative_weight/baseline_weight
 


### PR DESCRIPTION
Raise an error on zero baseline weights. This prevents bins from having nan counts.

There may be a future case for having a zero baseline weight for some events. If this ever emerges, this needs to be adapted.